### PR TITLE
Add a `unique_id` to the sensor

### DIFF
--- a/custom_components/radioactivity_hu/sensor.py
+++ b/custom_components/radioactivity_hu/sensor.py
@@ -127,3 +127,7 @@ class RadioactivityHUSensor(Entity):
     @property
     def icon(self):
         return DEFAULT_ICON
+
+    @property
+    def unique_id(self):
+        return self._name + "_" + self._station


### PR DESCRIPTION
With this property set, it becomes possible to customize the entity from HA UI.